### PR TITLE
Implement role-based access and add employee tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "axios": "^1.9.0",

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,55 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+
+export type Role = 'Administrador' | 'Gerente/RRHH' | 'Asistente de RRHH' | 'Empleado';
+
+interface AuthState {
+  token: string | null;
+  role: Role | null;
+}
+
+interface AuthContextValue {
+  auth: AuthState;
+  login: (token: string, role: Role) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  auth: { token: null, role: null },
+  login: () => {},
+  logout: () => {},
+});
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [auth, setAuth] = useState<AuthState>({ token: null, role: null });
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    const role = localStorage.getItem('role') as Role | null;
+    if (token && role) {
+      setAuth({ token, role });
+    }
+  }, []);
+
+  const login = (token: string, role: Role) => {
+    setAuth({ token, role });
+    localStorage.setItem('token', token);
+    localStorage.setItem('role', role);
+  };
+
+  const logout = () => {
+    setAuth({ token: null, role: null });
+    localStorage.removeItem('token');
+    localStorage.removeItem('role');
+  };
+
+  return (
+    <AuthContext.Provider value={{ auth, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/context/ProtectedRoute.tsx
+++ b/src/context/ProtectedRoute.tsx
@@ -1,0 +1,11 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from './AuthContext';
+import type { ReactNode } from 'react';
+
+export default function ProtectedRoute({ children }: { children: ReactNode }) {
+  const { auth } = useAuth();
+  if (!auth.token) {
+    return <Navigate to="/" replace />;
+  }
+  return <>{children}</>;
+}

--- a/src/context/RequireRole.tsx
+++ b/src/context/RequireRole.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+import { useAuth, type Role } from './AuthContext';
+
+export default function RequireRole({ roles, children }: { roles: Role[]; children: ReactNode }) {
+  const { auth } = useAuth();
+  if (!auth.role || !roles.includes(auth.role)) {
+    return <p>No autorizado</p>;
+  }
+  return <>{children}</>;
+}

--- a/src/layout/DashboardLayout.tsx
+++ b/src/layout/DashboardLayout.tsx
@@ -1,9 +1,11 @@
 import { Link, Outlet, useLocation } from 'react-router-dom';
 import { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
 
 export default function DashboardLayout() {
     const [defOpen, setDefOpen] = useState(false);
     const location = useLocation();
+    const { auth, logout } = useAuth();
 
     return (
         <div style={{ display: 'flex', height: '100vh', fontFamily: 'sans-serif' }}>
@@ -26,16 +28,21 @@ export default function DashboardLayout() {
 
                         {defOpen && (
                             <div style={{ paddingLeft: 12, display: 'flex', flexDirection: 'column', gap: 6 }}>
-                                <Link to="/dashboard/personales" style={navLink(location.pathname === '/dashboard/personales')}>
-                                    👤 Personales
-                                </Link>
-                                <Link to="/dashboard/cargos" style={navLink(location.pathname === '/dashboard/cargos')}>
-                                    📌 Cargos
-                                </Link>
-
-                                <Link to="/dashboard/rubros" style={navLink(location.pathname === '/dashboard/rubros')}>
-                                    📋 Rubros/Conceptos
-                                </Link>
+                                {(auth.role === 'Administrador' || auth.role === 'Gerente/RRHH' || auth.role === 'Asistente de RRHH') && (
+                                    <Link to="/dashboard/personales" style={navLink(location.pathname === '/dashboard/personales')}>
+                                        👤 Personales
+                                    </Link>
+                                )}
+                                {(auth.role === 'Administrador' || auth.role === 'Asistente de RRHH') && (
+                                    <Link to="/dashboard/cargos" style={navLink(location.pathname === '/dashboard/cargos')}>
+                                        📌 Cargos
+                                    </Link>
+                                )}
+                                {auth.role === 'Administrador' && (
+                                    <Link to="/dashboard/rubros" style={navLink(location.pathname === '/dashboard/rubros')}>
+                                        📋 Rubros/Conceptos
+                                    </Link>
+                                )}
 
                             </div>
                         )}
@@ -48,7 +55,7 @@ export default function DashboardLayout() {
                 <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 20 }}>
                     <button
                         onClick={() => {
-                            localStorage.removeItem('token');
+                            logout();
                             window.location.href = '/';
                         }}
                         style={{

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,21 +6,54 @@ import DashboardLayout from './layout/DashboardLayout';
 import Personales from './pages/Personales';
 import Cargos from './pages/Cargos';
 import Rubros from './pages/Rubros';
+import { AuthProvider, type Role } from './context/AuthContext';
+import ProtectedRoute from './context/ProtectedRoute';
+import RequireRole from './context/RequireRole';
 
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Login />} />
-        <Route path="/dashboard" element={<DashboardLayout />}>
-          <Route path="personales" element={<Personales />} />
-          <Route path="cargos" element={<Cargos />} />
-          <Route path="rubros" element={<Rubros />} />
-        </Route>
-        <Route path="*" element={<Navigate to="/" />} />
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<Login />} />
+          <Route
+            path="/dashboard"
+            element={
+              <ProtectedRoute>
+                <DashboardLayout />
+              </ProtectedRoute>
+            }
+          >
+            <Route
+              path="personales"
+              element={
+                <RequireRole roles={["Administrador", "Gerente/RRHH", "Asistente de RRHH"]}>
+                  <Personales />
+                </RequireRole>
+              }
+            />
+            <Route
+              path="cargos"
+              element={
+                <RequireRole roles={["Administrador", "Asistente de RRHH"]}>
+                  <Cargos />
+                </RequireRole>
+              }
+            />
+            <Route
+              path="rubros"
+              element={
+                <RequireRole roles={["Administrador"]}>
+                  <Rubros />
+                </RequireRole>
+              }
+            />
+          </Route>
+          <Route path="*" element={<Navigate to="/" />} />
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   </StrictMode>
 );
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuth, type Role } from '../context/AuthContext';
 
 export default function Login() {
     const [user, setUser] = useState('');
     const [clave, setClave] = useState('');
     const [mensaje, setMensaje] = useState('');
     const navigate = useNavigate();
+    const { login } = useAuth();
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -21,7 +23,8 @@ export default function Login() {
             const data = await res.json();
 
             if (data.estado === 1) {
-                localStorage.setItem('token', data.token);
+                const rol: Role = (data.rol || data.role) as Role;
+                login(data.token, rol);
                 navigate('/dashboard/');
             } else {
                 setMensaje(data.mensaje || 'Credenciales incorrectas');

--- a/src/pages/Personales.tsx
+++ b/src/pages/Personales.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
+import { filterEmployees } from '../utils/employee.js';
 
 export default function Personales() {
     const [personas, setPersonas] = useState([]);
@@ -57,11 +58,10 @@ export default function Personales() {
             .catch(err => console.error("Error al cargar países:", err));
     };
 
-    const personasFiltradas = personas.filter((p: any) => {
-        const coincideNombre = p.nombre.toLowerCase().includes(filtroNombre.toLowerCase());
-        const coincideApellido = p.apellido.toLowerCase().includes(filtroApellido.toLowerCase());
-        const coincideDocumento = (p.documento || '').includes(filtroDocumento);
-        return coincideNombre && coincideApellido && coincideDocumento;
+    const personasFiltradas = filterEmployees(personas as any, {
+        nombre: filtroNombre,
+        apellido: filtroApellido,
+        documento: filtroDocumento,
     });
 
     const handleGuardar = async () => {

--- a/src/utils/employee.js
+++ b/src/utils/employee.js
@@ -1,0 +1,10 @@
+export function filterEmployees(personas, { nombre = '', apellido = '', documento = '' } = {}) {
+  const n = nombre.toLowerCase();
+  const a = apellido.toLowerCase();
+  return personas.filter((p) => {
+    const coincideNombre = p.nombre.toLowerCase().includes(n);
+    const coincideApellido = p.apellido.toLowerCase().includes(a);
+    const coincideDocumento = (p.documento || '').includes(documento);
+    return coincideNombre && coincideApellido && coincideDocumento;
+  });
+}

--- a/tests/employee.test.js
+++ b/tests/employee.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { filterEmployees } from '../src/utils/employee.js';
+
+test('filter by nombre', () => {
+  const empleados = [
+    { nombre: 'Ana', apellido: 'Lopez', documento: '123' },
+    { nombre: 'Juan', apellido: 'Perez', documento: '456' },
+  ];
+  const res = filterEmployees(empleados, { nombre: 'ana' });
+  assert.equal(res.length, 1);
+  assert.equal(res[0].apellido, 'Lopez');
+});
+
+test('filter by multiple fields', () => {
+  const empleados = [
+    { nombre: 'Ana', apellido: 'Lopez', documento: '123' },
+    { nombre: 'Ana', apellido: 'Gomez', documento: '999' },
+  ];
+  const res = filterEmployees(empleados, { nombre: 'ana', apellido: 'lo' });
+  assert.deepEqual(res, [{ nombre: 'Ana', apellido: 'Lopez', documento: '123' }]);
+});


### PR DESCRIPTION
## Summary
- add authentication context with roles
- protect routes according to role
- adjust dashboard navigation and login to use context
- extract employee filtering logic to util
- add unit tests for employee filtering

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68589faa08188332b21764a8d8cb7907